### PR TITLE
Initial data preprocessing

### DIFF
--- a/R/data-processing.R
+++ b/R/data-processing.R
@@ -1,0 +1,45 @@
+#' Process and export data
+#' 
+#' Takes the triangular data in Frank.xlsx and converts it to long format,
+#'   appending dev (development period in months) and calendar year in the
+#'   process.
+process_and_export <- function(input_path, output_path) {
+  require(tidyverse)
+  require(readxl)
+  data <- input_path %>%
+    excel_sheets() %>%
+    set_names() %>%
+    map(~ read_xlsx(path = input_path, sheet = .x)) %>%
+    map( ~ .x %>%
+           gather(dev, value, `12`:`528`) %>% # convert to long format
+           mutate_at(vars(c("AccidentYear", "ClaimNb"), starts_with("Report")), 
+                     as.integer) %>%
+           rename(accident_year = AccidentYear,
+                  claim_number = ClaimNb,
+                  status = Status) %>%
+           # calculate calendar year
+           mutate(calendar_year = accident_year + as.integer(dev) / 12 - 1) %>%
+           filter(value > 0)
+    )
+  
+  liability_data <- data[["Liability"]] %>%
+    rename(transaction_type = Transaction,
+           occupancy = Occupancy,
+           report_year = ReportingYear,
+           cover_type = CoverType) %>%
+    mutate(occupancy = occupancy %>% # convert occupancy to '01', '02', etc.
+             gsub("^Lob", "", .) %>%
+             str_pad(2, side = "left", pad = "0"),
+           lob = "Liability")
+  
+  motor_data <- data[["Motor"]] %>%
+    rename(transaction_type = Type,
+           report_year = ReportYear) %>%
+    mutate(lob = "Motor")
+  
+  # combined the datasets
+  combined_data <- bind_rows(liability_data, motor_data)
+  write_csv(combined_data, output_path)
+}
+
+process_and_export("data/Frank.xlsx", "data/combined_data_full.csv")

--- a/R/hello.R
+++ b/R/hello.R
@@ -1,1 +1,0 @@
-# R source code should go in R/

--- a/reports/eda.Rmd
+++ b/reports/eda.Rmd
@@ -10,36 +10,24 @@ knitr::opts_knit$set(root.dir = rprojroot::find_rstudio_root_file())
 
 ## Exploratory data analysis
 
-We provide high level descriptive statistics on the data. Note that we should refrain from showing detailed information from all but the first few calendar years available before we decide on a validation approach to prevent leakage. The input data has also been scaled to provide further anonymity. Feel free to edit/correct/append or otherwise contribute to this document.
+We provide high level descriptive statistics on the data. Note that we should refrain from showing detailed information from all but the first few calendar years available before we decide on a validation approach to prevent leakage. Feel free to edit/correct/append or otherwise contribute to this document.
 
-### Summary by LOB
+### Year ranges by LOB
+
+The following table shows the first and last accident year, calendar year, and report years for which transactions exist for each of the LOB.
 
 ```{r echo = FALSE, message = FALSE}
-library(readr)
-library(dplyr)
-library(tidyr)
-library(stringr)
-raw <- read_csv("data/data_f.csv")
-lob_summary <- raw %>%
-  rename(accident_year = AccidentYear,
-         transaction_type = Transaction,
-         claim_number = ClaimNb,
-         lob = Occupancy,
-         reporting_year = ReportingYear,
-         cover_type = CoverType,
-         status = Status) %>%
-  mutate(lob = lob %>%
-           gsub("^Lob", "", .) %>%
-           str_pad(2, side = "left", pad = "0"),
-         calendar_year = accident_year + dev / 12 - 1) %>%
+library(tidyverse)
+data <- read_csv("data/combined_data_full.csv")
+lob_summary <- data %>%
   group_by(lob, cover_type) %>%
   filter(value > 0) %>%
   summarize(first_ay = min(accident_year),
             last_ay = max(accident_year),
             first_cy = min(calendar_year),
             last_cy = max(calendar_year),
-            first_ry = min(reporting_year),
-            last_ry = max(reporting_year))
+            first_ry = min(report_year),
+            last_ry = max(report_year))
 ```
 
 ```{r, echo = FALSE, result = "asis"}

--- a/reports/eda.md
+++ b/reports/eda.md
@@ -4,31 +4,14 @@ Initial Exploratory Data Analysis (WIP)
 Exploratory data analysis
 -------------------------
 
-We provide high level descriptive statistics on the data. Note that we should refrain from showing detailed information from all but the first few calendar years available before we decide on a validation approach to prevent leakage. The input data has also been scaled to provide further anonymity. Feel free to edit/correct/append or otherwise contribute to this document.
+We provide high level descriptive statistics on the data. Note that we should refrain from showing detailed information from all but the first few calendar years available before we decide on a validation approach to prevent leakage. Feel free to edit/correct/append or otherwise contribute to this document.
 
-### Summary by LOB
+### Year ranges by LOB
 
-| lob | cover\_type |  first\_ay|  last\_ay|  first\_cy|  last\_cy|  first\_ry|  last\_ry|
-|:----|:------------|----------:|---------:|----------:|---------:|----------:|---------:|
-| 01  | ClaimsMade  |       1985|      2016|       1990|      2016|       1990|      2016|
-| 01  | Occurence   |       1980|      2012|       1984|      2016|       1985|      2015|
-| 02  | ClaimsMade  |       1993|      1999|       1997|      2016|       1997|      2007|
-| 02  | Occurence   |       1976|      2010|       1981|      2016|       1981|      2011|
-| 03  | ClaimsMade  |       2000|      2014|       2001|      2016|       2000|      2016|
-| 03  | Occurence   |       1983|      2004|       1984|      2016|       1984|      2010|
-| 04  | ClaimsMade  |       1993|      2001|       1998|      2016|       1996|      2005|
-| 04  | Occurence   |       1979|      2009|       1979|      2016|       1985|      2012|
-| 05  | ClaimsMade  |       1987|      2004|       1990|      2016|       1987|      2006|
-| 05  | Occurence   |       1975|      2014|       1980|      2016|       1980|      2016|
-| 06  | ClaimsMade  |       1983|      2014|       1990|      2016|       1984|      2016|
-| 06  | Occurence   |       1979|      2012|       1980|      2016|       1980|      2013|
-| 07  | ClaimsMade  |       1988|      2015|       1991|      2016|       1991|      2016|
-| 07  | Occurence   |       1982|      2014|       1988|      2016|       1988|      2016|
-| 08  | ClaimsMade  |       1984|      2013|       1990|      2016|       1988|      2015|
-| 08  | Occurence   |       1976|      2014|       1980|      2016|       1980|      2014|
-| 09  | ClaimsMade  |       1984|      2015|       1990|      2016|       1986|      2015|
-| 09  | Occurence   |       1975|      2015|       1980|      2016|       1981|      2016|
-| 10  | ClaimsMade  |       1999|      2004|       2002|      2016|       2002|      2008|
-| 10  | Occurence   |       1979|      2008|       1980|      2016|       1985|      2016|
-| 11  | ClaimsMade  |       1990|      2011|       1991|      2016|       1991|      2012|
-| 11  | Occurence   |       1974|      2014|       1984|      2016|       1985|      2014|
+The following table shows the first and last accident year, calendar year, and report years for which transactions exist for each of the LOB.
+
+| lob       | cover\_type |  first\_ay|  last\_ay|  first\_cy|  last\_cy|  first\_ry|  last\_ry|
+|:----------|:------------|----------:|---------:|----------:|---------:|----------:|---------:|
+| Liability | ClaimsMade  |       1983|      2016|       1990|      2016|       1984|      2016|
+| Liability | Occurence   |       1974|      2015|       1979|      2016|       1980|      2016|
+| Motor     | NA          |       1973|      2016|       1987|      2016|       1973|      2016|


### PR DESCRIPTION
This change (closes #5)
- Adds a `process_and_export()` function that takes the triangular in `Frank.xlsx` and transforms it to long format, adding `dev` and `calendar_year` columns.
- Updates the initial EDA template (preview [here](https://github.com/kevinykuo/MLTMS/blob/feature/data-preprocessing/reports/eda.md)) to reflect the updated data processing logic.

Note that the output of `process_and_export()` contains ALL data, so it needs to be filtered further before it can be passed on to the modeling subgroups.